### PR TITLE
fix: Prevent race condition in optimistic publisher

### DIFF
--- a/internal/sqladapter/adapter.go
+++ b/internal/sqladapter/adapter.go
@@ -37,3 +37,8 @@ func (a *DBAdapter) ExecContext(ctx context.Context, query string, args ...any) 
 	_, err := a.DB.ExecContext(ctx, query, args...)
 	return err
 }
+
+// ExecContextWithResult executes a query and returns the sql.Result for advanced use-cases (e.g., checking affected rows).
+func (a *DBAdapter) ExecContextWithResult(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	return a.DB.ExecContext(ctx, query, args...)
+}

--- a/internal/sqladapter/types.go
+++ b/internal/sqladapter/types.go
@@ -14,4 +14,6 @@ type Tx interface {
 type Executor interface {
 	BeginTx(ctx context.Context) (Tx, error)
 	ExecContext(ctx context.Context, query string, args ...any) error
+	// ExecContextWithResult executes a query and returns the sql.Result for advanced use-cases (e.g., checking affected rows).
+	ExecContextWithResult(ctx context.Context, query string, args ...any) (sql.Result, error)
 }


### PR DESCRIPTION
This PR resolves a race condition where the optimistic publisher could delete a message that the `Reader` had already processed for a retry, causing lost updates and misleading error logs. The fix makes the optimistic `DELETE` operation conditional on `times_attempted = 0`, ensuring it backs off if the `Reader` has already intervened.

-   Updated `internal/sqladapter` to expose `sql.Result` for checking affected rows.
-   Modified `pkg/outbox/writer.go` to use the conditional `DELETE`.
-   Added new unit tests in `pkg/outbox/writer_test.go` to cover this logic.

You can verify the change by running the new unit tests:

```sh
go test -v ./pkg/outbox
```